### PR TITLE
Fix Express module not found error in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test:poc": "node -e \"fetch('http://localhost:3001/meal-poc').then(r=>r.json()).then(console.log).catch(console.error)\""
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0",
     "lucide-react": "^0.344.0",
     "openai": "^5.5.1",
     "react": "^18.3.1",
@@ -44,11 +46,9 @@
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.18",
     "concurrently": "^9.1.2",
-    "dotenv": "^16.5.0",
     "eslint": "^9.9.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
-    "express": "^5.1.0",
     "globals": "^15.9.0",
     "jsdom": "^26.1.0",
     "msw": "^2.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       lucide-react:
         specifier: ^0.344.0
         version: 0.344.0(react@18.3.1)
@@ -72,9 +78,6 @@ importers:
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
-      dotenv:
-        specifier: ^16.5.0
-        version: 16.5.0
       eslint:
         specifier: ^9.9.1
         version: 9.29.0(jiti@1.21.7)
@@ -84,9 +87,6 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.11
         version: 0.4.20(eslint@9.29.0(jiti@1.21.7))
-      express:
-        specifier: ^5.1.0
-        version: 5.1.0
       globals:
         specifier: ^15.9.0
         version: 15.15.0


### PR DESCRIPTION
- Move express and dotenv from devDependencies to dependencies
- These packages are required at runtime for the server to function
- Update pnpm-lock.yaml to reflect correct dependency structure
- Verify tests and build still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)