### PR TITLE
Fix Express 5.x routing compatibility for Railway deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -337,7 +337,7 @@ app.post('/reroll-meal', async (req, res) => {
 });
 
 // Catch-all route to serve React app for client-side routing
-app.get('*', (req, res) => {
+app.get('/*', (req, res) => {
   res.sendFile(path.resolve(process.cwd(), 'dist', 'index.html'));
 });
 


### PR DESCRIPTION
Change catch-all route from '*' to '/*' to resolve path-to-regexp@8.x parsing error that was causing deployment failures on Railway.

🤖 Generated with [Claude Code](https://claude.ai/code)