### PR TITLE
Fix GitHub Actions syntax errors in claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     
     # Allow multiple Claude instances to work on different issues/PRs simultaneously
     concurrency:
-      group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.issue_url | split('/') | last }}
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
       cancel-in-progress: false
     
     runs-on: ubuntu-latest
@@ -30,7 +30,6 @@ jobs:
       issues: write # Required for creating and updating issues
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
-      metadata: read # Required for repository metadata
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Fix concurrency group expression using github.run_id instead of invalid pipe operators
- Remove invalid metadata permission that caused workflow validation failure
- Ensure workflow passes GitHub Actions YAML validation

🤖 Generated with [Claude Code](https://claude.ai/code)