### PR TITLE
Fix Railway deployment workflow syntax error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Deploy to Railway
+      - name: Setup Railway CLI
         uses: railwayapp/cli-action@v1
         with:
           railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      
+      - name: Deploy to Railway
         run: railway up --detach


### PR DESCRIPTION
- Split Railway CLI setup and deployment into separate steps
- Fix incorrect placement of run command as parameter to Railway action
- Ensure proper YAML syntax for GitHub Actions workflow
- Railway deployment should now work correctly on push to main

🤖 Generated with [Claude Code](https://claude.ai/code)