### PR TITLE
Fix Railway deployment by replacing non-existent GitHub Action with C…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Setup Railway CLI
-        uses: railwayapp/cli-action@v1
-        with:
-          railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      - name: Install Railway CLI
+        run: |
+          curl -fsSL https://railway.app/install.sh | sh
+          echo "$HOME/.railway/bin" >> $GITHUB_PATH
       
       - name: Deploy to Railway
         run: railway up --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
…LI installation

- Remove railwayapp/cli-action@v1 which doesn't exist and causes deployment failures
- Install Railway CLI manually using official install script
- Set RAILWAY_TOKEN as environment variable for proper authentication
- Add Railway CLI to PATH for command availability
- Ensure reliable deployment process without dependency on non-existent actions

🤖 Generated with [Claude Code](https://claude.ai/code)